### PR TITLE
Changed the type for password field in kafka config

### DIFF
--- a/component/loki/source/kafka/kafka.go
+++ b/component/loki/source/kafka/kafka.go
@@ -53,7 +53,7 @@ type KafkaAuthentication struct {
 type KafkaSASLConfig struct {
 	Mechanism   string            `river:"mechanism,attr,optional"`
 	User        string            `river:"user,attr,optional"`
-	Password    string            `river:"password,attr,optional"`
+	Password    flagext.Secret    `river:"password,attr,optional"`
 	UseTLS      bool              `river:"use_tls,attr,optional"`
 	TLSConfig   config.TLSConfig  `river:"tls_config,block,optional"`
 	OAuthConfig OAuthConfigConfig `river:"oauth_config,block,optional"`
@@ -192,13 +192,13 @@ func (args *Arguments) Convert() kt.Config {
 }
 
 func (auth KafkaAuthentication) Convert() kt.Authentication {
-	var secret flagext.Secret
-	if auth.SASLConfig.Password != "" {
-		err := secret.Set(auth.SASLConfig.Password)
-		if err != nil {
-			panic("Unable to set kafka SASLConfig password")
-		}
-	}
+	// var secret flagext.Secret
+	// if auth.SASLConfig.Password.String() != "" {
+	// 	err := secret.Set(auth.SASLConfig.Password)
+	// 	if err != nil {
+	// 		panic("Unable to set kafka SASLConfig password")
+	// 	}
+	// }
 
 	return kt.Authentication{
 		Type:      kt.AuthenticationType(auth.Type),
@@ -206,7 +206,7 @@ func (auth KafkaAuthentication) Convert() kt.Authentication {
 		SASLConfig: kt.SASLConfig{
 			Mechanism: sarama.SASLMechanism(auth.SASLConfig.Mechanism),
 			User:      auth.SASLConfig.User,
-			Password:  secret,
+			Password:  auth.SASLConfig.Password,
 			UseTLS:    auth.SASLConfig.UseTLS,
 			TLSConfig: *auth.SASLConfig.TLSConfig.Convert(),
 			OAuthConfig: kt.OAuthConfig{

--- a/component/loki/source/kafka/kafka_test.go
+++ b/component/loki/source/kafka/kafka_test.go
@@ -59,6 +59,8 @@ func TestSASLRiverConfig(t *testing.T) {
 	var args Arguments
 	err := river.Unmarshal([]byte(exampleRiverConfig), &args)
 	require.NoError(t, err)
+
+	require.NotEqual(t, "password", args.Authentication.SASLConfig.Password.String())
 }
 
 func TestSASLOAuthRiverConfig(t *testing.T) {


### PR DESCRIPTION

The `Password` field in `kafka.go` was set to string, which caused it to be exposed. This PR fixes it by changing its type to `flagext.Secret`, which ensures that the value is not exposed directly without explicit calling to its `String()` method

- Fixes #4636

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [x] Tests updated
