### PR TITLE
Modified the Password field to use rivertypes.Secret

### DIFF
--- a/component/loki/source/kafka/kafka.go
+++ b/component/loki/source/kafka/kafka.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/agent/component/common/loki"
 	flow_relabel "github.com/grafana/agent/component/common/relabel"
 	kt "github.com/grafana/agent/component/loki/source/internal/kafkatarget"
+	"github.com/grafana/agent/pkg/river/rivertypes"
 	"github.com/grafana/dskit/flagext"
 	"github.com/prometheus/common/model"
 )
@@ -24,6 +25,16 @@ func init() {
 			return New(opts, args.(Arguments))
 		},
 	})
+}
+
+// Takes in a variable of type `rivertypes.Secret`, converts it to an OptionalSecret in order to extract the string value
+func ConvertSecretToString(secret rivertypes.Secret) (string, error) {
+	var optSecret rivertypes.OptionalSecret
+	err := secret.ConvertInto(&optSecret)
+	if err != nil {
+		return "", err
+	}
+	return optSecret.Value, nil
 }
 
 // Arguments holds values which are used to configure the loki.source.kafka
@@ -53,7 +64,7 @@ type KafkaAuthentication struct {
 type KafkaSASLConfig struct {
 	Mechanism   string            `river:"mechanism,attr,optional"`
 	User        string            `river:"user,attr,optional"`
-	Password    flagext.Secret    `river:"password,attr,optional"`
+	Password    rivertypes.Secret `river:"password,attr,optional"`
 	UseTLS      bool              `river:"use_tls,attr,optional"`
 	TLSConfig   config.TLSConfig  `river:"tls_config,block,optional"`
 	OAuthConfig OAuthConfigConfig `river:"oauth_config,block,optional"`
@@ -192,21 +203,14 @@ func (args *Arguments) Convert() kt.Config {
 }
 
 func (auth KafkaAuthentication) Convert() kt.Authentication {
-	// var secret flagext.Secret
-	// if auth.SASLConfig.Password.String() != "" {
-	// 	err := secret.Set(auth.SASLConfig.Password)
-	// 	if err != nil {
-	// 		panic("Unable to set kafka SASLConfig password")
-	// 	}
-	// }
-
+	password, _ := ConvertSecretToString(auth.SASLConfig.Password)
 	return kt.Authentication{
 		Type:      kt.AuthenticationType(auth.Type),
 		TLSConfig: *auth.TLSConfig.Convert(),
 		SASLConfig: kt.SASLConfig{
 			Mechanism: sarama.SASLMechanism(auth.SASLConfig.Mechanism),
 			User:      auth.SASLConfig.User,
-			Password:  auth.SASLConfig.Password,
+			Password:  flagext.SecretWithValue(password),
 			UseTLS:    auth.SASLConfig.UseTLS,
 			TLSConfig: *auth.SASLConfig.TLSConfig.Convert(),
 			OAuthConfig: kt.OAuthConfig{

--- a/component/loki/source/kafka/kafka_test.go
+++ b/component/loki/source/kafka/kafka_test.go
@@ -60,7 +60,10 @@ func TestSASLRiverConfig(t *testing.T) {
 	err := river.Unmarshal([]byte(exampleRiverConfig), &args)
 	require.NoError(t, err)
 
-	require.NotEqual(t, "password", args.Authentication.SASLConfig.Password.String())
+	// Ensures that the rivertype.Secret is working properly and there's no error
+	password, err_ := ConvertSecretToString(args.Authentication.SASLConfig.Password)
+	require.NoError(t, err_)
+	require.Equal(t, "password", password)
 }
 
 func TestSASLOAuthRiverConfig(t *testing.T) {

--- a/converter/internal/promtailconvert/internal/build/kafka.go
+++ b/converter/internal/promtailconvert/internal/build/kafka.go
@@ -52,7 +52,7 @@ func convertKafkaAuthConfig(kafkaCfg *scrapeconfig.KafkaTargetConfig) kafka.Kafk
 		SASLConfig: kafka.KafkaSASLConfig{
 			Mechanism: string(kafkaCfg.Authentication.SASLConfig.Mechanism),
 			User:      kafkaCfg.Authentication.SASLConfig.User,
-			Password:  kafkaCfg.Authentication.SASLConfig.Password.String(),
+			Password:  rivertypes.Secret(kafkaCfg.Authentication.SASLConfig.Password.String()),
 			UseTLS:    kafkaCfg.Authentication.SASLConfig.UseTLS,
 			TLSConfig: *prometheusconvert.ToTLSConfig(&kafkaCfg.Authentication.SASLConfig.TLSConfig),
 		},

--- a/docs/sources/flow/reference/components/loki.source.kafka.md
+++ b/docs/sources/flow/reference/components/loki.source.kafka.md
@@ -107,12 +107,12 @@ you must set the `tls_config` block. If `"sasl"` is used, you must set the `sasl
 The `sasl_config` block defines the listen address and port where the listener
 expects Kafka messages to be sent to.
 
- Name        | Type     | Description                                                                   | Default    | Required 
--------------|----------|-------------------------------------------------------------------------------|------------|----------
- `mechanism` | `string` | Specifies the SASL mechanism the client uses to authenticate with the broker. | `"PLAIN""` | no       
- `user`      | `string` | The user name to use for SASL authentication.                                 | `""`       | no       
- `password`  | `string` | The password to use for SASL authentication.                                  | `""`       | no       
- `use_tls`   | `bool`   | If true, SASL authentication is executed over TLS.                            | `false`    | no       
+ Name        | Type                 | Description                                                                   | Default    | Required 
+-------------|----------------------|--------------------------------------------------------------------|----------|-----------------------
+ `mechanism` | `string`             | Specifies the SASL mechanism the client uses to authenticate with the broker. | `"PLAIN""` | no       
+ `user`      | `string`             | The user name to use for SASL authentication.                                 | `""`       | no       
+ `password`  | `rivertypes.Secret`  | The password to use for SASL authentication.                                  | `""`       | no       
+ `use_tls`   | `bool`               | If true, SASL authentication is executed over TLS.                            | `false`    | no       
 
 ### oauth_config block
 


### PR DESCRIPTION
The `Password` field in `kafka.go` was set to string, which caused it to be exposed. This PR fixes it by changing its type to `flagext.Secret`, which ensures that the value is not exposed directly without explicit calling to its `String()` method

- Fixes #4636

#### PR Checklist

- [ ] CHANGELOG updated
- [ ] Documentation added
- [x] Tests updated